### PR TITLE
CPS-601: Add Prospects Scenarios

### DIFF
--- a/engine_scripts/puppet/action-dropdown.js
+++ b/engine_scripts/puppet/action-dropdown.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const Utility = require('./../utility.js');
+const Utility = require('./utility.js');
 
 module.exports = async (page, scenario, vp) => {
   const utility = new Utility(page, scenario, vp);

--- a/engine_scripts/puppet/manage-cases/action-dropdown-change-status.js
+++ b/engine_scripts/puppet/manage-cases/action-dropdown-change-status.js
@@ -6,6 +6,8 @@ module.exports = async (page, scenario, vp) => {
   const utility = new Utility(page, scenario, vp);
 
   await require('./action-dropdown')(page, scenario, vp);
-  await page.click('.civicase__case-header__action-menu .btn-group:last-child .dropdown-menu li:nth-child(1) a');
+  await page.evaluate(() => {
+    CRM.$('.civicase__case-header__action-menu .btn-group:last-child .dropdown-menu li a:contains("Change Case Status")').click();
+  });
   await utility.waitForUIModalLoad();
 };

--- a/engine_scripts/puppet/manage-cases/action-dropdown-change-status.js
+++ b/engine_scripts/puppet/manage-cases/action-dropdown-change-status.js
@@ -5,7 +5,7 @@ const Utility = require('./../utility.js');
 module.exports = async (page, scenario, vp) => {
   const utility = new Utility(page, scenario, vp);
 
-  await require('./action-dropdown')(page, scenario, vp);
+  await require('../action-dropdown')(page, scenario, vp);
   await page.evaluate(() => {
     CRM.$('.civicase__case-header__action-menu .btn-group:last-child .dropdown-menu li a:contains("Change Case Status")').click();
   });

--- a/engine_scripts/puppet/manage-cases/action-dropdown-delete.js
+++ b/engine_scripts/puppet/manage-cases/action-dropdown-delete.js
@@ -1,7 +1,7 @@
 'use strict';
 
 module.exports = async (page, scenario, vp) => {
-  await require('./action-dropdown')(page, scenario, vp);
+  await require('../action-dropdown')(page, scenario, vp);
   await page.evaluate(() => {
     CRM.$('.civicase__case-header__action-menu .btn-group:last-child .dropdown-menu li a:contains("Delete Case")').click();
   });

--- a/engine_scripts/puppet/manage-cases/action-dropdown-delete.js
+++ b/engine_scripts/puppet/manage-cases/action-dropdown-delete.js
@@ -2,5 +2,7 @@
 
 module.exports = async (page, scenario, vp) => {
   await require('./action-dropdown')(page, scenario, vp);
-  await page.click('.civicase__case-header__action-menu .btn-group:last-child .dropdown-menu li .fa-trash');
+  await page.evaluate(() => {
+    CRM.$('.civicase__case-header__action-menu .btn-group:last-child .dropdown-menu li a:contains("Delete Case")').click();
+  });
 };

--- a/engine_scripts/puppet/manage-cases/action-dropdown-edit-tags.js
+++ b/engine_scripts/puppet/manage-cases/action-dropdown-edit-tags.js
@@ -2,6 +2,8 @@
 
 module.exports = async (page, scenario, vp) => {
   await require('./action-dropdown')(page, scenario, vp);
-  await page.click('.civicase__case-header__action-menu .btn-group:last-child .dropdown-menu li .fa-tags');
+  await page.evaluate(() => {
+    CRM.$('.civicase__case-header__action-menu .btn-group:last-child .dropdown-menu li a:contains("Edit Tags")').click();
+  });
   await page.waitForTimeout(2000);
 };

--- a/engine_scripts/puppet/manage-cases/action-dropdown-edit-tags.js
+++ b/engine_scripts/puppet/manage-cases/action-dropdown-edit-tags.js
@@ -1,7 +1,7 @@
 'use strict';
 
 module.exports = async (page, scenario, vp) => {
-  await require('./action-dropdown')(page, scenario, vp);
+  await require('../action-dropdown')(page, scenario, vp);
   await page.evaluate(() => {
     CRM.$('.civicase__case-header__action-menu .btn-group:last-child .dropdown-menu li a:contains("Edit Tags")').click();
   });

--- a/engine_scripts/puppet/manage-cases/action-dropdown-email-case-manager.js
+++ b/engine_scripts/puppet/manage-cases/action-dropdown-email-case-manager.js
@@ -1,7 +1,0 @@
-'use strict';
-
-module.exports = async (page, scenario, vp) => {
-  await require('./action-dropdown')(page, scenario, vp);
-  await page.click('.civicase__case-header__action-menu .btn-group:last-child .dropdown-menu li .fa-envelope-o');
-  await page.waitForSelector('.civicase__email-role-selector');
-};

--- a/engine_scripts/puppet/manage-cases/action-dropdown-export.js
+++ b/engine_scripts/puppet/manage-cases/action-dropdown-export.js
@@ -6,6 +6,8 @@ module.exports = async (page, scenario, vp) => {
   const utility = new Utility(page, scenario, vp);
 
   await require('./action-dropdown')(page, scenario, vp);
-  await page.click('.civicase__case-header__action-menu .btn-group:last-child .dropdown-menu li .fa-file-excel-o');
+  await page.evaluate(() => {
+    CRM.$('.civicase__case-header__action-menu .btn-group:last-child .dropdown-menu li a:contains("Export Cases")').click();
+  });
   await utility.waitForUIModalLoad();
 };

--- a/engine_scripts/puppet/manage-cases/action-dropdown-export.js
+++ b/engine_scripts/puppet/manage-cases/action-dropdown-export.js
@@ -5,7 +5,7 @@ const Utility = require('./../utility.js');
 module.exports = async (page, scenario, vp) => {
   const utility = new Utility(page, scenario, vp);
 
-  await require('./action-dropdown')(page, scenario, vp);
+  await require('../action-dropdown')(page, scenario, vp);
   await page.evaluate(() => {
     CRM.$('.civicase__case-header__action-menu .btn-group:last-child .dropdown-menu li a:contains("Export Cases")').click();
   });

--- a/engine_scripts/puppet/manage-cases/action-dropdown-link.js
+++ b/engine_scripts/puppet/manage-cases/action-dropdown-link.js
@@ -2,6 +2,8 @@
 
 module.exports = async (page, scenario, vp) => {
   await require('./action-dropdown')(page, scenario, vp);
-  await page.click('.civicase__case-header__action-menu .btn-group:last-child .dropdown-menu li .fa-link');
+  await page.evaluate(() => {
+    CRM.$('.civicase__case-header__action-menu .btn-group:last-child .dropdown-menu li a:contains("Link Cases")').click();
+  });
   await page.waitForTimeout(2000);
 };

--- a/engine_scripts/puppet/manage-cases/action-dropdown-link.js
+++ b/engine_scripts/puppet/manage-cases/action-dropdown-link.js
@@ -1,7 +1,7 @@
 'use strict';
 
 module.exports = async (page, scenario, vp) => {
-  await require('./action-dropdown')(page, scenario, vp);
+  await require('../action-dropdown')(page, scenario, vp);
   await page.evaluate(() => {
     CRM.$('.civicase__case-header__action-menu .btn-group:last-child .dropdown-menu li a:contains("Link Cases")').click();
   });

--- a/engine_scripts/puppet/manage-cases/action-dropdown-lock.js
+++ b/engine_scripts/puppet/manage-cases/action-dropdown-lock.js
@@ -5,7 +5,7 @@ const Utility = require('./../utility.js');
 module.exports = async (page, scenario, vp) => {
   const utility = new Utility(page, scenario, vp);
 
-  await require('./action-dropdown')(page, scenario, vp);
+  await require('../action-dropdown')(page, scenario, vp);
   await page.evaluate(() => {
     CRM.$('.civicase__case-header__action-menu .btn-group:last-child .dropdown-menu li a:contains("Lock Case")').click();
   });

--- a/engine_scripts/puppet/manage-cases/action-dropdown-lock.js
+++ b/engine_scripts/puppet/manage-cases/action-dropdown-lock.js
@@ -6,6 +6,8 @@ module.exports = async (page, scenario, vp) => {
   const utility = new Utility(page, scenario, vp);
 
   await require('./action-dropdown')(page, scenario, vp);
-  await page.click('.civicase__case-header__action-menu .btn-group:last-child .dropdown-menu li .fa-lock');
+  await page.evaluate(() => {
+    CRM.$('.civicase__case-header__action-menu .btn-group:last-child .dropdown-menu li a:contains("Lock Case")').click();
+  });
   await utility.waitForUIModalLoad();
 };

--- a/engine_scripts/puppet/manage-cases/action-dropdown-print-merge.js
+++ b/engine_scripts/puppet/manage-cases/action-dropdown-print-merge.js
@@ -6,6 +6,8 @@ module.exports = async (page, scenario, vp) => {
   const utility = new Utility(page, scenario, vp);
 
   await require('./action-dropdown')(page, scenario, vp);
-  await page.click('.civicase__case-header__action-menu .btn-group:last-child .dropdown-menu li .fa-file-pdf-o');
+  await page.evaluate(() => {
+    CRM.$('.civicase__case-header__action-menu .btn-group:last-child .dropdown-menu li a:contains("Print Case")').click();
+  });
   await utility.waitForUIModalLoad();
 };

--- a/engine_scripts/puppet/manage-cases/action-dropdown-print-merge.js
+++ b/engine_scripts/puppet/manage-cases/action-dropdown-print-merge.js
@@ -5,7 +5,7 @@ const Utility = require('./../utility.js');
 module.exports = async (page, scenario, vp) => {
   const utility = new Utility(page, scenario, vp);
 
-  await require('./action-dropdown')(page, scenario, vp);
+  await require('../action-dropdown')(page, scenario, vp);
   await page.evaluate(() => {
     CRM.$('.civicase__case-header__action-menu .btn-group:last-child .dropdown-menu li a:contains("Print Case")').click();
   });

--- a/engine_scripts/puppet/manage-prospectings/click-contribution-button.js
+++ b/engine_scripts/puppet/manage-prospectings/click-contribution-button.js
@@ -4,11 +4,8 @@ const Utility = require('../utility.js');
 
 module.exports = async (page, scenario, vp) => {
   const utility = new Utility(page, scenario, vp);
-  await utility.waitForAngular();
-  await utility.waitForLoadingComplete();
 
-  await page.click('.civicase__case-header__action-icon.btn.btn-primary');
-
+  await require('../action-dropdown')(page, scenario, vp);
   await page.evaluate(() => {
     CRM.$('.civicase__case-header__action-menu .btn-group:last-child .dropdown-menu li a:contains("Convert to Contribution")').click();
   });

--- a/engine_scripts/puppet/manage-prospectings/click-contribution-button.js
+++ b/engine_scripts/puppet/manage-prospectings/click-contribution-button.js
@@ -1,0 +1,16 @@
+'use strict';
+
+const Utility = require('../utility.js');
+
+module.exports = async (page, scenario, vp) => {
+  const utility = new Utility(page, scenario, vp);
+  await utility.waitForAngular();
+  await utility.waitForLoadingComplete();
+
+  await page.click('.civicase__case-header__action-icon.btn.btn-primary');
+
+  await page.evaluate(() => {
+    CRM.$('.civicase__case-header__action-menu .btn-group:last-child .dropdown-menu li a:contains("Convert to Contribution")').click();
+  });
+  await utility.waitForUIModalLoad();
+};

--- a/engine_scripts/puppet/manage-prospectings/click-pledge-button.js
+++ b/engine_scripts/puppet/manage-prospectings/click-pledge-button.js
@@ -4,11 +4,8 @@ const Utility = require('../utility.js');
 
 module.exports = async (page, scenario, vp) => {
   const utility = new Utility(page, scenario, vp);
-  await utility.waitForAngular();
-  await utility.waitForLoadingComplete();
 
-  await page.click('.civicase__case-header__action-icon');
-
+  await require('../action-dropdown')(page, scenario, vp);
   await page.evaluate(() => {
     CRM.$('.civicase__case-header__action-menu .btn-group:last-child .dropdown-menu li a:contains("Convert to Pledge")').click();
   });

--- a/engine_scripts/puppet/manage-prospectings/click-pledge-button.js
+++ b/engine_scripts/puppet/manage-prospectings/click-pledge-button.js
@@ -1,0 +1,16 @@
+'use strict';
+
+const Utility = require('../utility.js');
+
+module.exports = async (page, scenario, vp) => {
+  const utility = new Utility(page, scenario, vp);
+  await utility.waitForAngular();
+  await utility.waitForLoadingComplete();
+
+  await page.click('.civicase__case-header__action-icon');
+
+  await page.evaluate(() => {
+    CRM.$('.civicase__case-header__action-menu .btn-group:last-child .dropdown-menu li a:contains("Convert to Pledge")').click();
+  });
+  await utility.waitForUIModalLoad();
+};

--- a/gulp-tasks/backstopjs.js
+++ b/gulp-tasks/backstopjs.js
@@ -80,7 +80,7 @@ function cleanUp () {
  */
 function createTempConfig () {
   var group = argv.group ? argv.group : '_all_';
-  var list = buildScenariosList(group, ['civicase', 'civiawards', 'usermenu']);
+  var list = buildScenariosList(group, ['civicase', 'civiawards', 'usermenu', 'prospect']);
   var content = JSON.parse(fs.readFileSync(CONFIGS.FILES.tpl));
 
   content.scenarios = list.map((item) => {

--- a/gulp-tasks/data-setup-steps/activity.service.js
+++ b/gulp-tasks/data-setup-steps/activity.service.js
@@ -17,6 +17,7 @@ const service = {
 function setupData () {
   createCaseActivities();
   createAwardsActivities();
+  createProspectingActivities();
 
   console.log('Activities data setup successful.');
 }
@@ -93,6 +94,19 @@ function createAwardsActivities () {
     ['custom_' + paymentTypeFieldID]: 1,
     ['custom_' + paymentCurrencyTypeFieldID]: 'USD',
     ['custom_' + paymentAmountValueFieldID]: '5000'
+  });
+}
+
+/**
+ * Create Prospecting Activities
+ */
+function createProspectingActivities () {
+  createUniqueActivity({
+    source_contact_id: contactService.activeContact.id,
+    activity_date_time: moment().startOf('month').format('YYYY-MM-DD'),
+    subject: 'Backstop Follow Up',
+    case_id: caseService.activeProspectingId,
+    activity_type_id: 'Follow up'
   });
 }
 

--- a/gulp-tasks/data-setup-steps/activity.service.js
+++ b/gulp-tasks/data-setup-steps/activity.service.js
@@ -17,7 +17,6 @@ const service = {
 function setupData () {
   createCaseActivities();
   createAwardsActivities();
-  createProspectingActivities();
 
   console.log('Activities data setup successful.');
 }
@@ -94,19 +93,6 @@ function createAwardsActivities () {
     ['custom_' + paymentTypeFieldID]: 1,
     ['custom_' + paymentCurrencyTypeFieldID]: 'USD',
     ['custom_' + paymentAmountValueFieldID]: '5000'
-  });
-}
-
-/**
- * Create Prospecting Activities
- */
-function createProspectingActivities () {
-  createUniqueActivity({
-    source_contact_id: contactService.activeContact.id,
-    activity_date_time: moment().startOf('month').format('YYYY-MM-DD'),
-    subject: 'Backstop Follow Up',
-    case_id: caseService.activeProspectingId,
-    activity_type_id: 'Follow up'
   });
 }
 

--- a/gulp-tasks/data-setup-steps/case.service.js
+++ b/gulp-tasks/data-setup-steps/case.service.js
@@ -2,6 +2,7 @@ const _ = require('lodash');
 const createUniqueRecordFactory = require('../utils/create-unique-record-factory.js');
 const caseTypeService = require('./case-type.service.js');
 const awardService = require('./award.service.js');
+const prospectService = require('./prospect.service.js');
 const contactService = require('./contact.service.js');
 const createUniqueCase = createUniqueRecordFactory('Case', ['subject']);
 
@@ -9,9 +10,11 @@ const service = {
   setupData,
   caseSubject: 'Backstop Case',
   awardApplicationSubject: 'Backstop Award Application',
+  prospectingSubject: 'Backstop Prospecting',
   emptyCaseSubject: 'Backstop Empty Case',
   activeCaseID: null,
-  activeAwardApplicationId: null
+  activeAwardApplicationId: null,
+  activeProspectingId: null
 };
 
 /**
@@ -44,6 +47,15 @@ function setupData () {
   );
 
   service.activeAwardApplicationId = awardApplicationIds[0];
+
+  const prospectingIds = createCases(
+    1,
+    service.prospectingSubject,
+    prospectService.prospect,
+    contactService.activeContact
+  );
+
+  service.activeProspectingId = prospectingIds[0];
 
   console.log('Case data setup successful.');
 }

--- a/gulp-tasks/data-setup-steps/prospect.service.js
+++ b/gulp-tasks/data-setup-steps/prospect.service.js
@@ -1,0 +1,44 @@
+const createUniqueRecordFactory = require('../utils/create-unique-record-factory.js');
+const createUniqueProspect = createUniqueRecordFactory('CaseType', ['name']);
+
+const service = {
+  setupData,
+  prospect: null,
+  prospectName: 'backstop_prospect',
+  prospectTitle: 'Backstop Prospect'
+};
+
+/**
+ * Create Prospect
+ */
+function setupData () {
+  service.prospect = createUniqueProspect({
+    name: service.prospectName,
+    case_type_category: 'Prospecting',
+    title: service.prospectTitle,
+    definition: {
+      activityTypes: [{
+        name: 'Phone Call'
+      }, {
+        name: 'Meeting'
+      }],
+      activitySets: [{
+        timeline: true,
+        name: 'standard_timeline',
+        label: 'Standard Timeline'
+      }],
+      caseRoles: [
+        {
+          name: 'Prospect Owner',
+          manager: '1'
+        }
+      ],
+      statuses: ['enquiry', 'qualified', 'in_progress', 'submitted', 'won', 'lost'],
+      timelineActivityTypes: []
+    }
+  });
+
+  console.log('Prospect data setup successful.');
+}
+
+module.exports = service;

--- a/gulp-tasks/setup-data.js
+++ b/gulp-tasks/setup-data.js
@@ -6,6 +6,7 @@ const entityTagService = require('./data-setup-steps/entity-tag.service.js');
 const activityService = require('./data-setup-steps/activity.service.js');
 const relationshipService = require('./data-setup-steps/relationship.service.js');
 const awardService = require('./data-setup-steps/award.service.js');
+const prospectService = require('./data-setup-steps/prospect.service.js');
 const awardFinanceManagement = require('./data-setup-steps/award-finance-management.service.js');
 const caseService = require('./data-setup-steps/case.service.js');
 const customGroupService = require('./data-setup-steps/custom-group.service.js');
@@ -35,6 +36,7 @@ async function setupData () {
   tagService.setupData();
   contactService.setupData();
   awardService.setupData();
+  prospectService.setupData();
   awardFinanceManagement.setupData();
   caseService.setupData();
   activityService.setupData();

--- a/gulp-tasks/utils/get-active-prospecting-id.js
+++ b/gulp-tasks/utils/get-active-prospecting-id.js
@@ -1,0 +1,25 @@
+const cvApi = require('./cv-api.js');
+
+module.exports = getActiveProspectingId;
+
+/**
+ * Returns the ID of a application that is active and has an activity for the current
+ * calendar month.
+ *
+ * @returns {number} case id of an active case
+ */
+function getActiveProspectingId () {
+  var activity = cvApi('Activity', 'get', {
+    sequential: 1,
+    'case_id.is_deleted': 0,
+    case_filter: { 'case_type_id.case_type_category': 'prospecting' },
+    return: ['case_id'],
+    options: { limit: 1 }
+  });
+
+  if (!activity.count) {
+    throw new Error('Please add an activity for a prospecting');
+  }
+
+  return activity.count && activity.values[0].case_id[0];
+}

--- a/gulp-tasks/utils/get-active-prospecting-id.js
+++ b/gulp-tasks/utils/get-active-prospecting-id.js
@@ -3,23 +3,34 @@ const cvApi = require('./cv-api.js');
 module.exports = getActiveProspectingId;
 
 /**
- * Returns the ID of a application that is active and has an activity for the current
- * calendar month.
+ * Returns the ID of one of the existent prospects.
  *
- * @returns {number} case id of an active case
+ * @returns {number} prospect id
  */
 function getActiveProspectingId () {
-  var activity = cvApi('Activity', 'get', {
+  const prospectTypeId = cvApi('CaseType', 'get', {
     sequential: 1,
-    'case_id.is_deleted': 0,
-    case_filter: { 'case_type_id.case_type_category': 'prospecting' },
-    return: ['case_id'],
+    is_active: 1,
+    case_type_category: 'Prospecting',
+    return: ['id'],
     options: { limit: 1 }
   });
 
-  if (!activity.count) {
-    throw new Error('Please add an activity for a prospecting');
+  if (!prospectTypeId.count) {
+    throw new Error('Please add a prospect type');
   }
 
-  return activity.count && activity.values[0].case_id[0];
+  const prospecting = cvApi('Case', 'get', {
+    sequential: 1,
+    is_deleted: 0,
+    case_type_id: prospectTypeId.values[0].id,
+    return: ['id'],
+    options: { limit: 1 }
+  });
+
+  if (!prospecting.count) {
+    throw new Error('Please add a prospecting');
+  }
+
+  return prospecting.values[0].id;
 }

--- a/gulp-tasks/utils/replace-url-vars.js
+++ b/gulp-tasks/utils/replace-url-vars.js
@@ -4,6 +4,7 @@ const CONFIGS = require('./configs.js');
 const getActiveCaseId = require('./get-active-case-id.js');
 const getCaseTypeCategoryName = require('./get-case-type-category-value.js');
 const getActiveApplicationId = require('./get-active-application-id.js');
+const getActiveProspectingId = require('./get-active-prospecting-id');
 const casesService = require('../data-setup-steps/case.service.js');
 
 var CACHE = {
@@ -26,8 +27,10 @@ function replaceUrlVars (url) {
   const URL_VAR_REPLACERS = [
     replaceCasesCTCVar,
     replaceAwardsCTCVar,
+    replaceProspectsCTCVar,
     replaceCaseIdVar,
     replaceApplicationIdVar,
+    replaceProspectingIdVar,
     replaceEmptyCaseIdVar,
     replaceRootUrlVar,
     replaceContactIdVar
@@ -88,6 +91,21 @@ function replaceAwardsCTCVar (url, config) {
 }
 
 /**
+ * Replaces the `{ctc-prospects}` var with the value of the "prospects" Case type category.
+ *
+ * @param {string} url the scenario url.
+ * @param {object} config the site config options.
+ * @returns {string} replaced record id
+ */
+function replaceProspectsCTCVar (url, config) {
+  return url.replace(/{ctc-prospecting}/g, function () {
+    return getRecordIdFromCacheOrCallback('ctc-prospecting', function () {
+      return getCaseTypeCategoryName('prospecting');
+    });
+  });
+}
+
+/**
  * Replaces the `{caseId}` var with the id of the first non deleted, open case.
  *
  * @param {string} url the scenario url.
@@ -112,6 +130,20 @@ function replaceApplicationIdVar (url, config) {
     return getRecordIdFromCacheOrCallback('applicationId', getActiveApplicationId);
   });
 }
+
+/**
+ * Replaces the `{applicationId}` var with the id of the first non deleted, open application.
+ *
+ * @param {string} url the scenario url.
+ * @param {object} config the site config options.
+ * @returns {string} replaced record id
+ */
+function replaceProspectingIdVar (url, config) {
+  return url.replace('{prospectingId}', function () {
+    return getRecordIdFromCacheOrCallback('prospectingId', getActiveProspectingId);
+  });
+}
+
 
 /**
  * Replaces the `{emptyCaseId}` var with the id for the empty case created by the setup script.

--- a/scenarios/civicase/manage-cases.json
+++ b/scenarios/civicase/manage-cases.json
@@ -98,7 +98,7 @@
     {
       "label": "Manage Cases - Case Overview - Action Dropdown",
       "url": "{url}/civicrm/case/a/?case_type_category={ctc-cases}#/case/list?cf=%7B\"case_type_category\":\"{ctc-cases}\"%7D&caseId={caseId}",
-      "onReadyScript": "manage-cases/action-dropdown.js"
+      "onReadyScript": "action-dropdown.js"
     },
     {
       "label": "Manage Cases - Case Overview - Action Dropdown - Change case status",

--- a/scenarios/prospect/manage-prospectings.json
+++ b/scenarios/prospect/manage-prospectings.json
@@ -1,19 +1,19 @@
 {
   "scenarios": [
     {
-      "label": "Prospects - Case Overview - Menu Displayed",
+      "label": "Manage Prospects - Case Overview - Case Action Menu",
       "url": "{url}/civicrm/case/a/?case_type_category={ctc-prospecting}#/case/list?cf=%7B\"case_type_category\":\"{ctc-prospecting}\"%7D&caseId={prospectingId}",
       "waitForLoadingComplete": ".civicase__summary-tab",
       "clickSelector": ".civicase__case-header__action-icon"
     },
     {
-      "label": "Prospects - Case Overview - Convert to Pledge",
+      "label": "Manage Prospects - Case Overview - Action Dropdown - Convert to Pledge",
       "url": "{url}/civicrm/case/a/?case_type_category={ctc-prospecting}#/case/list?cf=%7B\"case_type_category\":\"{ctc-prospecting}\"%7D&caseId={prospectingId}",
       "waitForLoadingComplete": ".civicase__summary-tab",
       "onReadyScript": "manage-prospectings/click-pledge-button.js"
     },
     {
-      "label": "Prospects - Case Overview - Convert to Contribution",
+      "label": "Manage Prospects - Case Overview - Action Dropdown - Convert to Contribution",
       "url": "{url}/civicrm/case/a/?case_type_category={ctc-prospecting}#/case/list?cf=%7B\"case_type_category\":\"{ctc-prospecting}\"%7D&caseId={prospectingId}",
       "waitForLoadingComplete": ".civicase__summary-tab",
       "onReadyScript": "manage-prospectings/click-contribution-button.js"

--- a/scenarios/prospect/manage-prospectings.json
+++ b/scenarios/prospect/manage-prospectings.json
@@ -1,0 +1,22 @@
+{
+  "scenarios": [
+    {
+      "label": "Prospects - Case Overview - Menu Displayed",
+      "url": "{url}/civicrm/case/a/?case_type_category={ctc-prospecting}#/case/list?cf=%7B\"case_type_category\":\"{ctc-prospecting}\"%7D&caseId={prospectingId}",
+      "waitForLoadingComplete": ".civicase__summary-tab",
+      "clickSelector": ".civicase__case-header__action-icon"
+    },
+    {
+      "label": "Prospects - Case Overview - Convert to Pledge",
+      "url": "{url}/civicrm/case/a/?case_type_category={ctc-prospecting}#/case/list?cf=%7B\"case_type_category\":\"{ctc-prospecting}\"%7D&caseId={prospectingId}",
+      "waitForLoadingComplete": ".civicase__summary-tab",
+      "onReadyScript": "manage-prospectings/click-pledge-button.js"
+    },
+    {
+      "label": "Prospects - Case Overview - Convert to Contribution",
+      "url": "{url}/civicrm/case/a/?case_type_category={ctc-prospecting}#/case/list?cf=%7B\"case_type_category\":\"{ctc-prospecting}\"%7D&caseId={prospectingId}",
+      "waitForLoadingComplete": ".civicase__summary-tab",
+      "onReadyScript": "manage-prospectings/click-contribution-button.js"
+    }
+  ]
+}


### PR DESCRIPTION
## Overview
This PR adds the testing scenarios related to prospects extension, along with the data setup needed.

## Before
Neither the scenarios nor the data existed.

## After
The new scenarios were added:
- Menu displayed on a prospect:
![Civicase51_Prospects_-_Case_Overview_-_Menu_Displayed_0_document_0_desktop](https://user-images.githubusercontent.com/74304572/129184419-aba3ead3-90bf-482b-8b90-ded9afc4afcb.png)
- Click on Convert to Contribution:
![Civicase51_Prospects_-_Case_Overview_-_Convert_to_Contribution_0_document_0_desktop](https://user-images.githubusercontent.com/74304572/129184477-d3063f4f-dee7-4a03-81bc-2e31134ef921.png)
- Click on Convert to Pledge:
![Civicase51_Prospects_-_Case_Overview_-_Convert_to_Pledge_0_document_0_desktop](https://user-images.githubusercontent.com/74304572/129184509-ed00e48b-7e64-4f9b-8f05-c21f128174e7.png)
Also, it was added a prospect in the data setup.

## Comments
- The click on menu items was refactored also on manage cases scenarios. Now it is selected by the text of the link, not for the position. It was tested locally that the change worked as expected.
- The file `action-dropdown-email-case-manager.js` was deleted since it was not in use anymore.
