### PR TITLE
CPS-601: Add Prospects to GitHub action

### DIFF
--- a/.github/workflows/backstop.yml
+++ b/.github/workflows/backstop.yml
@@ -3,50 +3,29 @@ name: Backstop Tests
 on:
   workflow_dispatch:
     inputs:
-      civicase_reference_branch:
-        description: CiviCase Reference Branch/Tag Name
-        default: master
+      civicase_branch:
+        description: 'Enter CiviCase Reference and Test Branch/Tag Name separated by a comma(Example: master,staging)'
+        default: master,
         required: true
-      civicase_test_branch:
-        description: CiviCase Test Branch/tag Name
+      civiawards_branch:
+        description: 'Enter CiviAwards Reference and Test Branch/Tag Name separated by a comma(Example: master,staging)'
+        default: master,
         required: true
-      civiawards_reference_branch:
-        description: CiviAwards Reference Branch/Tag Name
-        default: master
+      prospect_branch:
+        description: 'Enter Prospect Reference and Test Branch/Tag Name separated by a comma(Example: master,staging)'
+        default: master,
         required: true
-      civiawards_test_branch:
-        description: CiviAwards Test Branch/tag Name
+      civicrm_branch:
+        description: 'Enter CiviCRM Reference and Test Branch/Tag Name separated by a comma(Example: master,staging)'
+        default: 5.35,5.35 # change this to the current civicrm version in use
         required: true
-      prospect_reference_branch:
-        description: Prospect Reference Branch/Tag Name
-        default: master
+      shoreditch_branch:
+        description: 'Enter Shoreditch Reference and Test Branch/Tag Name separated by a comma(Example: master,staging)'
+        default: master,master
         required: true
-      prospect_test_branch:
-        description: Prospect Test Branch/tag Name
-        required: true
-      civicrm_reference_version:
-        description: CiviCRM Reference Version
-        default: 5.35 # change this to the current civicrm version in use
-        required: true
-      civicrm_test_version:
-        description: CiviCRM Test Version
-        default: 5.35 # change this to the current civicrm version in use
-        required: true
-      reference_shoreditch_branch:
-        description: Shoreditch Reference Branch/Tag Name
-        default: master
-        required: true
-      test_shoreditch_branch:
-        description: Shoreditch Test Branch/Tag Name
-        default: master
-        required: true
-      reference_usermenu_branch:
-        description: Usermenu Reference Branch/Tag Name
-        default: master
-        required: true
-      test_usermenu_branch:
-        description: Usermenu Test Branch/Tag Name
-        default: master
+      usermenu_branch:
+        description: 'Enter Usermenu Reference and Test Branch/Tag Name separated by a comma(Example: master,staging)'
+        default: master,master
         required: true
 
 jobs:
@@ -73,6 +52,37 @@ jobs:
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
 
     steps:
+      - uses: jungwinter/split@v1
+        id: civicase_branch
+        with:
+          msg: ${{ github.event.inputs.civicase_branch }}
+          seperator: ',' # is seperator, note the typo, which is incorrect on the imported action.
+      - uses: jungwinter/split@v1
+        id: civiawards_branch
+        with:
+          msg: ${{ github.event.inputs.civiawards_branch }}
+          seperator: ','
+      - uses: jungwinter/split@v1
+        id: prospect_branch
+        with:
+          msg: ${{ github.event.inputs.prospect_branch }}
+          seperator: ','
+      - uses: jungwinter/split@v1
+        id: civicrm_branch
+        with:
+          msg: ${{ github.event.inputs.civicrm_branch }}
+          seperator: ','
+      - uses: jungwinter/split@v1
+        id: shoreditch_branch
+        with:
+          msg: ${{ github.event.inputs.shoreditch_branch }}
+          seperator: ','
+      - uses: jungwinter/split@v1
+        id: usermenu_branch
+        with:
+          msg: ${{ github.event.inputs.usermenu_branch }}
+          seperator: ','
+
       - name: Config mysql database as per CiviCRM requirement
         run: echo "SET GLOBAL sql_mode=(SELECT REPLACE(@@sql_mode,'ONLY_FULL_GROUP_BY',''));" | mysql -u root --password=root --host=mysql
 
@@ -82,14 +92,14 @@ jobs:
           echo "IncludeOptional $HOME/.amp/apache.d/*.conf" >> /etc/apache2/apache2.conf
           /usr/sbin/apache2ctl restart
 
-      - name: Build Reference Drupal site (CiviCRM - ${{ github.event.inputs.civicrm_reference_version }}, CiviCase - ${{ github.event.inputs.civicase_reference_branch }}, CiviAwards - ${{ github.event.inputs.civiawards_reference_branch }}, Prospect - ${{ github.event.inputs.prospect_reference_branch }}, Shoreditch - ${{ github.event.inputs.reference_shoreditch_branch }})
+      - name: Build Reference Drupal site (CiviCRM - ${{ steps.civicrm_branch.outputs._0 }}, CiviCase - ${{ steps.civicase_branch.outputs._0 }}, CiviAwards - ${{ steps.civiawards_branch.outputs._0 }}, Prospect - ${{ steps.prospect_branch.outputs._0 }}, Shoreditch - ${{ steps.shoreditch_branch.outputs._0 }})
         run: |
-          civibuild create drupal-clean --civi-ver ${{ github.event.inputs.civicrm_reference_version }} --cms-ver 7.74 --web-root $GITHUB_WORKSPACE/${{ env.REFERENCE_SITE_FOLDER }} --url ${{ env.REFERENCE_SITE_URL }}
+          civibuild create drupal-clean --civi-ver ${{ steps.civicrm_branch.outputs._0 }} --cms-ver 7.74 --web-root $GITHUB_WORKSPACE/${{ env.REFERENCE_SITE_FOLDER }} --url ${{ env.REFERENCE_SITE_URL }}
           chmod -R 777 $GITHUB_WORKSPACE/${{ env.REFERENCE_SITE_FOLDER }}
 
-      - name: Build Test Drupal site (CiviCRM - ${{ github.event.inputs.civicrm_test_version }}, CiviCase - ${{ github.event.inputs.civicase_test_branch }}, CiviAwards - ${{ github.event.inputs.civiawards_test_branch }}, Prospect - ${{ github.event.inputs.prospect_test_branch }}, Shoreditch - ${{ github.event.inputs.test_shoreditch_branch }})
+      - name: Build Test Drupal site (CiviCRM - ${{ steps.civicrm_branch.outputs._1 }}, CiviCase - ${{ steps.civicase_branch.outputs._1 }}, CiviAwards - ${{ steps.civiawards_branch.outputs._1 }}, Prospect - ${{ steps.prospect_branch.outputs._1 }}, Shoreditch - ${{ steps.shoreditch_branch.outputs._1 }})
         run: |
-          civibuild create drupal-clean --civi-ver ${{ github.event.inputs.civicrm_test_version }} --cms-ver 7.74 --web-root $GITHUB_WORKSPACE/${{ env.TEST_SITE_FOLDER }} --url ${{ env.TEST_SITE_URL }}
+          civibuild create drupal-clean --civi-ver ${{ steps.civicrm_branch.outputs._1 }} --cms-ver 7.74 --web-root $GITHUB_WORKSPACE/${{ env.TEST_SITE_FOLDER }} --url ${{ env.TEST_SITE_URL }}
           chmod -R 777 $GITHUB_WORKSPACE/${{ env.TEST_SITE_FOLDER }}
 
       - name: Install BackstopJS
@@ -104,11 +114,11 @@ jobs:
       - name: Installing CiviCase, CiviAwards, Prospect and Shoreditch in Reference Site
         working-directory: ${{ env.REFERENCE_SITE_FOLDER }}/${{ env.CIVICRM_EXTENSIONS_DIR }}
         run: |
-          git clone https://github.com/compucorp/uk.co.compucorp.civicase.git --branch ${{ github.event.inputs.civicase_reference_branch }}
-          git clone https://github.com/compucorp/uk.co.compucorp.civiawards --branch ${{ github.event.inputs.civiawards_reference_branch }}
-          git clone https://github.com/compucorp/uk.co.compucorp.civicrm.prospect --branch ${{ github.event.inputs.prospect_reference_branch }}
-          git clone https://github.com/civicrm/org.civicrm.shoreditch.git --branch ${{ github.event.inputs.reference_shoreditch_branch }}
-          git clone https://github.com/compucorp/uk.co.compucorp.usermenu --branch ${{ github.event.inputs.reference_usermenu_branch }}
+          git clone https://github.com/compucorp/uk.co.compucorp.civicase.git --branch ${{ steps.civicase_branch.outputs._0 }}
+          git clone https://github.com/compucorp/uk.co.compucorp.civiawards --branch ${{ steps.civiawards_branch.outputs._0 }}
+          git clone https://github.com/compucorp/uk.co.compucorp.civicrm.prospect --branch ${{ steps.prospect_branch.outputs._0 }}
+          git clone https://github.com/civicrm/org.civicrm.shoreditch.git --branch ${{ steps.shoreditch_branch.outputs._0 }}
+          git clone https://github.com/compucorp/uk.co.compucorp.usermenu --branch ${{ steps.usermenu_branch.outputs._0 }}
           cv en shoreditch usermenu civicase civiawards prospect
           drush en civicrmtheme -y
           drush en bootstrap -y
@@ -147,7 +157,7 @@ jobs:
           nvm use
           npx gulp backstopjs:setup-data
 
-      - name: Reference Screenshots in (CiviCRM - ${{ github.event.inputs.civicrm_reference_version }}, CiviCase - ${{ github.event.inputs.civicase_reference_branch }}, Shoreditch - ${{ github.event.inputs.reference_shoreditch_branch }})
+      - name: Reference Screenshots in (CiviCRM - ${{ steps.civicrm_branch.outputs._0 }}, CiviCase - ${{ steps.civicase_branch.outputs._0 }}, CiviAwards - ${{ steps.civiawards_branch.outputs._0 }}, Prospect - ${{ steps.prospect_branch.outputs._0 }}, Shoreditch - ${{ steps.shoreditch_branch.outputs._0 }})
         continue-on-error: true
         working-directory: ${{ env.BACKSTOP_DIR }}
         run: |
@@ -158,11 +168,11 @@ jobs:
       - name: Installing CiviCase, CiviAwards, Prospect and Shoreditch in Test Site
         working-directory: ${{ env.TEST_SITE_FOLDER }}/${{ env.CIVICRM_EXTENSIONS_DIR }}
         run: |
-          git clone https://github.com/compucorp/uk.co.compucorp.civicase.git --branch ${{ github.event.inputs.civicase_test_branch }}
-          git clone https://github.com/compucorp/uk.co.compucorp.civiawards --branch ${{ github.event.inputs.civiawards_test_branch }}
-          git clone https://github.com/compucorp/uk.co.compucorp.civicrm.prospect --branch ${{ github.event.inputs.prospect_test_branch }}
-          git clone https://github.com/civicrm/org.civicrm.shoreditch.git --branch ${{ github.event.inputs.test_shoreditch_branch }}
-          git clone https://github.com/compucorp/uk.co.compucorp.usermenu --branch ${{ github.event.inputs.test_usermenu_branch }}
+          git clone https://github.com/compucorp/uk.co.compucorp.civicase.git --branch ${{ steps.civicase_branch.outputs._1 }}
+          git clone https://github.com/compucorp/uk.co.compucorp.civiawards --branch ${{ steps.civiawards_branch.outputs._1 }}
+          git clone https://github.com/compucorp/uk.co.compucorp.civicrm.prospect --branch ${{ steps.prospect_branch.outputs._1 }}
+          git clone https://github.com/civicrm/org.civicrm.shoreditch.git --branch ${{ steps.shoreditch_branch.outputs._1 }}
+          git clone https://github.com/compucorp/uk.co.compucorp.usermenu --branch ${{ steps.usermenu_branch.outputs._1 }}
           cv en shoreditch usermenu civicase civiawards prospect
           drush en civicrmtheme -y
           drush en bootstrap -y
@@ -199,7 +209,7 @@ jobs:
           nvm use
           npx gulp backstopjs:setup-data
 
-      - name: Test Screenshots in (CiviCRM - ${{ github.event.inputs.civicrm_test_version }}, CiviCase - ${{ github.event.inputs.civicase_test_branch }}, Shoreditch - ${{ github.event.inputs.test_shoreditch_branch }})
+      - name: Test Screenshots in (CiviCRM - ${{ steps.civicrm_branch.outputs._1 }}, CiviCase - ${{ steps.civicase_branch.outputs._1 }}, CiviAwards - ${{ steps.civiawards_branch.outputs._1 }}, Prospect - ${{ steps.prospect_branch.outputs._1 }}, Shoreditch - ${{ steps.shoreditch_branch.outputs._1 }})
         continue-on-error: true
         working-directory: ${{ env.BACKSTOP_DIR }}
         run: |

--- a/.github/workflows/backstop.yml
+++ b/.github/workflows/backstop.yml
@@ -7,15 +7,22 @@ on:
         description: CiviCase Reference Branch/Tag Name
         default: master
         required: true
+      civicase_test_branch:
+        description: CiviCase Test Branch/tag Name
+        required: true
       civiawards_reference_branch:
         description: CiviAwards Reference Branch/Tag Name
         default: master
         required: true
-      civicase_test_branch:
-        description: CiviCase Test Branch/tag Name
-        required: true
       civiawards_test_branch:
         description: CiviAwards Test Branch/tag Name
+        required: true
+      prospect_reference_branch:
+        description: Prospect Reference Branch/Tag Name
+        default: master
+        required: true
+      prospect_test_branch:
+        description: Prospect Test Branch/tag Name
         required: true
       civicrm_reference_version:
         description: CiviCRM Reference Version
@@ -75,12 +82,12 @@ jobs:
           echo "IncludeOptional $HOME/.amp/apache.d/*.conf" >> /etc/apache2/apache2.conf
           /usr/sbin/apache2ctl restart
 
-      - name: Build Reference Drupal site (CiviCRM - ${{ github.event.inputs.civicrm_reference_version }}, CiviCase - ${{ github.event.inputs.civicase_reference_branch }}, CiviAwards - ${{ github.event.inputs.civiawards_reference_branch }}, Shoreditch - ${{ github.event.inputs.reference_shoreditch_branch }})
+      - name: Build Reference Drupal site (CiviCRM - ${{ github.event.inputs.civicrm_reference_version }}, CiviCase - ${{ github.event.inputs.civicase_reference_branch }}, CiviAwards - ${{ github.event.inputs.civiawards_reference_branch }}, Prospect - ${{ github.event.inputs.prospect_reference_branch }}, Shoreditch - ${{ github.event.inputs.reference_shoreditch_branch }})
         run: |
           civibuild create drupal-clean --civi-ver ${{ github.event.inputs.civicrm_reference_version }} --cms-ver 7.74 --web-root $GITHUB_WORKSPACE/${{ env.REFERENCE_SITE_FOLDER }} --url ${{ env.REFERENCE_SITE_URL }}
           chmod -R 777 $GITHUB_WORKSPACE/${{ env.REFERENCE_SITE_FOLDER }}
 
-      - name: Build Test Drupal site (CiviCRM - ${{ github.event.inputs.civicrm_test_version }}, CiviCase - ${{ github.event.inputs.civicase_test_branch }}, CiviAwards - ${{ github.event.inputs.civiawards_test_branch }}, Shoreditch - ${{ github.event.inputs.test_shoreditch_branch }})
+      - name: Build Test Drupal site (CiviCRM - ${{ github.event.inputs.civicrm_test_version }}, CiviCase - ${{ github.event.inputs.civicase_test_branch }}, CiviAwards - ${{ github.event.inputs.civiawards_test_branch }}, Prospect - ${{ github.event.inputs.prospect_test_branch }}, Shoreditch - ${{ github.event.inputs.test_shoreditch_branch }})
         run: |
           civibuild create drupal-clean --civi-ver ${{ github.event.inputs.civicrm_test_version }} --cms-ver 7.74 --web-root $GITHUB_WORKSPACE/${{ env.TEST_SITE_FOLDER }} --url ${{ env.TEST_SITE_URL }}
           chmod -R 777 $GITHUB_WORKSPACE/${{ env.TEST_SITE_FOLDER }}
@@ -94,14 +101,15 @@ jobs:
           nvm use
           npm install
 
-      - name: Installing CiviCase, CiviAwards and Shoreditch in Reference Site
+      - name: Installing CiviCase, CiviAwards, Prospect and Shoreditch in Reference Site
         working-directory: ${{ env.REFERENCE_SITE_FOLDER }}/${{ env.CIVICRM_EXTENSIONS_DIR }}
         run: |
           git clone https://github.com/compucorp/uk.co.compucorp.civicase.git --branch ${{ github.event.inputs.civicase_reference_branch }}
           git clone https://github.com/compucorp/uk.co.compucorp.civiawards --branch ${{ github.event.inputs.civiawards_reference_branch }}
+          git clone https://github.com/compucorp/uk.co.compucorp.civicrm.prospect --branch ${{ github.event.inputs.prospect_reference_branch }}
           git clone https://github.com/civicrm/org.civicrm.shoreditch.git --branch ${{ github.event.inputs.reference_shoreditch_branch }}
           git clone https://github.com/compucorp/uk.co.compucorp.usermenu --branch ${{ github.event.inputs.reference_usermenu_branch }}
-          cv en shoreditch usermenu civicase civiawards
+          cv en shoreditch usermenu civicase civiawards prospect
           drush en civicrmtheme -y
           drush en bootstrap -y
           drush vset theme_default bootstrap
@@ -147,14 +155,15 @@ jobs:
           nvm use
           npx gulp backstopjs:reference
 
-      - name: Installing CiviCase, CiviAwards and Shoreditch in Test Site
+      - name: Installing CiviCase, CiviAwards, Prospect and Shoreditch in Test Site
         working-directory: ${{ env.TEST_SITE_FOLDER }}/${{ env.CIVICRM_EXTENSIONS_DIR }}
         run: |
           git clone https://github.com/compucorp/uk.co.compucorp.civicase.git --branch ${{ github.event.inputs.civicase_test_branch }}
           git clone https://github.com/compucorp/uk.co.compucorp.civiawards --branch ${{ github.event.inputs.civiawards_test_branch }}
+          git clone https://github.com/compucorp/uk.co.compucorp.civicrm.prospect --branch ${{ github.event.inputs.prospect_test_branch }}
           git clone https://github.com/civicrm/org.civicrm.shoreditch.git --branch ${{ github.event.inputs.test_shoreditch_branch }}
           git clone https://github.com/compucorp/uk.co.compucorp.usermenu --branch ${{ github.event.inputs.test_usermenu_branch }}
-          cv en shoreditch usermenu civicase civiawards
+          cv en shoreditch usermenu civicase civiawards prospect
           drush en civicrmtheme -y
           drush en bootstrap -y
           drush vset theme_default bootstrap


### PR DESCRIPTION
## Overview
This PR includes on the GitHub action that runs the backstop tests, all the references and configuration for checking the [prospect repository](https://github.com/compucorp/uk.co.compucorp.civicrm.prospect)
And since the action is limited in the number of inputs to be included, we required to do a refactor on the way we received the reference and test branches/tags.

## Before
There was no prospects scenarios.
The input was limited to a maximum of 10, then it was not possible to add one more extension:
<img width="596" alt="Screen Shot 2021-08-13 at 18 33 15" src="https://user-images.githubusercontent.com/74304572/129351301-8925cc0f-6622-4961-b1b6-7f61a6b60cb6.png">

## After
The prospects scenarios are present.
There is one input for every extension, in which the reference and test branch should be specified separated by a comma:
<img width="596" alt="Screen Shot 2021-08-13 at 18 34 33" src="https://user-images.githubusercontent.com/74304572/129351424-cd79a94b-ece3-40c4-b0f8-fec207c5f1e5.png">

## Technical details
We use the external action https://github.com/marketplace/actions/split-action for splitting the input.
The code of this action has a typo on the parameter `separator` which is written instead as `seperator`. We added the value in that way. It was commented on the code appropriately.
